### PR TITLE
Update train_lora.py for kbit training in peft import

### DIFF
--- a/fingpt/FinGPT_Benchmark/train_lora.py
+++ b/fingpt/FinGPT_Benchmark/train_lora.py
@@ -23,7 +23,7 @@ from peft import (
     LoraConfig,
     get_peft_model,
     get_peft_model_state_dict,
-    prepare_model_for_int8_training,
+    prepare_model_for_kbit_training,
     set_peft_model_state_dict
 )
 from utils import *


### PR DESCRIPTION
As per title, int8 training in peft import is replaced by kbit training.